### PR TITLE
Set the upper bound of PyArrow as 3.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update
 RUN $APT_INSTALL software-properties-common git libxml2-dev pkg-config curl wget openjdk-8-jdk libpython3-dev python3-pip python3-setuptools python3.8
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
-RUN python3.8 -m pip install numpy pyarrow pandas scipy xmlrunner
+RUN python3.8 -m pip install numpy 'pyarrow<3.0.0' pandas scipy xmlrunner
 
 RUN add-apt-repository ppa:pypy/ppa
 RUN apt update


### PR DESCRIPTION
After https://github.com/apache/spark/commit/47a6568265525002021c1e5cfa4330f5b1a91469, we set 3.0.0 as the upper bound of PyArrow. According to semver, the breaking changes can happen in 3.0.0 legitimately. This is to avoid CI breakage.