### PR TITLE
Add step to upgrade pip and setuptools to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN $APT_INSTALL pypy3 gfortran libopenblas-dev liblapack-dev
 
 RUN $APT_INSTALL build-essential pypy3-dev
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | pypy3
+RUN pypy3 -m pip install -U pip setuptools
 RUN pypy3 -m pip install numpy pandas scipy coverage matplotlib
 
 RUN $APT_INSTALL gnupg ca-certificates pandoc


### PR DESCRIPTION
To fix issue:
```
 > [15/23] RUN pypy3 -m pip install numpy pandas scipy coverage matplotlib:
#17 19.37     import distutils.core
#17 19.37   File "/tmp/pip-build-env-hwjne39v/overlay/site-packages/_distutils_hack/__init__.py", line 99, in create_module
#17 19.37     return importlib.import_module('setuptools._distutils')
#17 19.37   File "/usr/lib/pypy3/lib-python/3/importlib/__init__.py", line 127, in import_module
#17 19.37     return _bootstrap._gcd_import(name[level:], package, level)
#17 19.37   File "<frozen importlib._bootstrap>", line 1015, in _gcd_import
#17 19.37   File "<frozen importlib._bootstrap>", line 992, in _find_and_load
#17 19.37   File "<frozen importlib._bootstrap>", line 974, in _find_and_load_unlocked
#17 19.37 ModuleNotFoundError: No module named 'setuptools._distutils'
#17 19.37 
```