### PR TITLE
Remove workaround of pypy3 setuptools upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,6 @@ RUN $APT_INSTALL pypy3 gfortran libopenblas-dev liblapack-dev
 
 RUN $APT_INSTALL build-essential pypy3-dev
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | pypy3
-RUN pypy3 -m pip install -U pip setuptools
 RUN pypy3 -m pip install numpy pandas scipy coverage matplotlib
 
 RUN $APT_INSTALL gnupg ca-certificates pandoc


### PR DESCRIPTION
@dongjoon-hyun You could merge this PR, or just close this and force update to remove the first commits.