### PR TITLE
Cleanup python3.8 related installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,6 @@ RUN apt-get update
 RUN $APT_INSTALL software-properties-common git libxml2-dev pkg-config curl wget openjdk-8-jdk libpython3-dev python3-pip python3-setuptools python3.8 python3.9
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.8
-RUN python3.8 -m pip install numpy 'pyarrow<3.0.0' pandas scipy xmlrunner plotly>=4.8 sklearn 'mlflow>=1.0'
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9
 RUN python3.9 -m pip install numpy pyarrow pandas scipy xmlrunner plotly>=4.8 sklearn 'mlflow>=1.0' coverage matplotlib
 


### PR DESCRIPTION
As https://github.com/dongjoon-hyun/ApacheSparkGitHubActionImage/issues/3#issuecomment-1003798463 , the python3.8 is not used by github action, it's time to cleanup python3.8 related installation.