### PR TITLE
[SPARK-37772] Support ApacheSparkGitHubActionImage arm64 docker image

### DIFF
--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -1,10 +1,10 @@
-name: ci
+name: ci (arm)
 
 on:
   push:
     paths:
-      - 'Dockerfile'
-      - '.github/workflows/build.yml'
+      - 'Dockerfile-arm64'
+      - '.github/workflows/build-arm.yml'
     branches: main
 
 jobs:
@@ -19,17 +19,19 @@ jobs:
         uses: docker/setup-buildx-action@v1
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
-        id: docker_build
+        id: docker_build_arm
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: dongjoon/apache-spark-github-action-image:latest
+          tags: dongjoon/apache-spark-github-action-image:arm64
+          file: ./Dockerfile-arm64
+          platforms: linux/arm64
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile-arm64
+++ b/Dockerfile-arm64
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Image for building and testing Spark branches. Based on Ubuntu 20.04.
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN true
+
+ARG APT_INSTALL="apt-get install --no-install-recommends -y"
+
+RUN apt-get clean
+RUN apt-get update
+RUN $APT_INSTALL software-properties-common git libxml2-dev pkg-config curl wget openjdk-8-jdk libpython3-dev python3-pip python3-setuptools python3.8 python3.9
+RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-arm64/jre/bin/java
+
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9
+RUN python3.9 -m pip install numpy pyarrow pandas scipy xmlrunner plotly>=4.8 sklearn 'mlflow>=1.0'
+
+RUN add-apt-repository ppa:pypy/ppa
+RUN apt update
+RUN $APT_INSTALL pypy3 gfortran libopenblas-dev liblapack-dev
+
+RUN $APT_INSTALL build-essential pypy3-dev
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py | pypy3
+# Skip scipy in aarch64, see related: https://github.com/scipy/scipy/issues/15316
+RUN pypy3 -m pip install numpy pandas


### PR DESCRIPTION


This patch adds the arm64 support for ApacheSparkGitHubActionImage. It would be used in PySpark arm64 scheduled job in future.

**Change items:**
This patch:
- Adds the `Dockerfile-arm64` and workflow, it would be published arm64 docker images to `dongjoon/apache-spark-github-action-image:arm64` as latest docker images.
- Changes the build CI only triggered separately when the specific arch dockerfile/workflow changed.

There are some different between arm64 and x86 Dockerfile:
- Install the `java-8-openjdk-arm64` rather than `java-8-openjdk-amd64`
- The `scipy` would not be installed in pypy3 due to known issue.
- The `sparkr` related dockerfile are not be supported yet.

**Build time:**
It takes about 5+ hours to complete arm64 build (1+ hours on x86) according my local build history, due to below reason:
- Docker buildx based on qemu, to enumlate the arm64 env on x86, so there will be a lot of performance loss.
- Numpy/Scipy/Pandas does not provide wheel installation, so it will spend some time on the source code compilation installation.

**Test:**
- Local build test in my docker repo: https://github.com/Yikun/ApacheSparkGitHubActionImage/pull/4
- Spark PySpark Test based on arm64 image: https://github.com/Yikun/spark/pull/53

**Related:**
See detail in [SPARK-37772](https://issues.apache.org/jira/browse/SPARK-37772).
