### PR TITLE
Add cache push support and limit pypy to 3.7 and numpy<1.23.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           push: true
           tags: dongjoon/apache-spark-github-action-image:latest
+          cache-to: type=registry,ref=dongjoon/apache-spark-github-action-image-cache:master,mode=max
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,15 +29,20 @@ RUN $APT_INSTALL software-properties-common git libxml2-dev pkg-config curl wget
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9
-RUN python3.9 -m pip install numpy pyarrow 'pandas<1.4.0' scipy xmlrunner plotly>=4.8 sklearn 'mlflow>=1.0' coverage matplotlib
+RUN python3.9 -m pip install 'numpy<1.23.0' pyarrow 'pandas<1.4.0' scipy xmlrunner plotly>=4.8 sklearn 'mlflow>=1.0' coverage matplotlib
 
 RUN add-apt-repository ppa:pypy/ppa
 RUN apt update
-RUN $APT_INSTALL pypy3 gfortran libopenblas-dev liblapack-dev
+RUN $APT_INSTALL gfortran libopenblas-dev liblapack-dev
 
-RUN $APT_INSTALL build-essential pypy3-dev
+RUN $APT_INSTALL build-essential
+RUN mkdir -p /usr/local/pypy/pypy3.7 && \
+    curl -sqL https://downloads.python.org/pypy/pypy3.7-v7.3.6-linux64.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.7 --strip-components=1 && \
+    ln -sf /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3.7 && \
+    ln -sf /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3
+
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | pypy3
-RUN pypy3 -m pip install numpy 'pandas<1.4.0' scipy coverage matplotlib
+RUN pypy3 -m pip install 'numpy<1.23.0' 'pandas<1.4.0' scipy coverage matplotlib
 
 RUN $APT_INSTALL gnupg ca-certificates pandoc
 RUN echo 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/' >> /etc/apt/sources.list


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1736354/175847692-8b1d708b-3ed3-4f21-8e12-8a728b8d97cf.png)

see more in https://docs.google.com/document/d/1_uiId-U1DODYyYZejAZeyz2OAjxcnA-xfwjynDF6vd0

- pypy to 3.7: https://issues.apache.org/jira/browse/SPARK-39609
- numpy<1.23.0: https://issues.apache.org/jira/browse/SPARK-39611